### PR TITLE
Improve molecule verification step

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -28,3 +28,33 @@
         - gitlab_edition is defined
         - gitlab_version is defined
         - gitlab_release is defined
+
+    - name: "Check GitLab Health endpoint"
+      ansible.builtin.uri:
+        url: "http://localhost/-/health"
+      register: "health_check"
+      failed_when: "'OK' not in health_check.msg or health_check.status!=200"
+
+    - name: "Check GitLab Readiness endpoint"
+      ansible.builtin.uri:
+        url: "http://localhost/-/readiness?all=1"
+      register: "readiness_check"
+      failed_when: "readiness_check.status == 503"
+
+    - name: "Check GitLab Liveness endpoint"
+      ansible.builtin.uri:
+        url: "http://localhost/-/liveness"
+      register: "liveness_check"
+      failed_when: "liveness_check.status == 503"
+
+    - name: "Check the output of gitlab status"
+      ansible.builtin.command: "gitlab-ctl status"
+      register: "gitlab_ctl_status"
+      changed_when: "gitlab_ctl_status.rc != 0"
+      failed_when: "gitlab_ctl_status.rc != 0"
+
+    - name: "Check GitLab configuration via Rake task"
+      ansible.builtin.command: "gitlab-rake gitlab:check"
+      register: "gitlab_rake_check"
+      changed_when: "gitlab_rake_check.rc != 0"
+      failed_when: "gitlab_rake_check.rc != 0"


### PR DESCRIPTION
So far the verification step was rather fundamental. This change adds test for certain additional cases:

* Check `gitlab-ctl status`
* Check `gitlab-rake gitlab:check`
* Check the health check endpoints:
  * `/-/health`
  * `/-/readiness`
  * `/-/liveness`

This should give us a far better understanding if GitLab is properly running in Molecule.

@christianhueserhzdr Could you please review? 

Closes #35 