### PR TITLE
Add Debian 11 (bullseye) as platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           - centos8
           - ubuntu1804
           - ubuntu2004
+          - debian11
 
     steps:
       - name: Check out the codebase.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,6 +26,9 @@ galaxy_info:
       versions:
         - bionic
         - focal
+    - name: Debian
+      versions:
+        - 11
 
   galaxy_tags:
     - git

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,7 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
-        - 11
+        - "11"
 
   galaxy_tags:
     - git

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 Helmholtz Centre for Environmental Research (UFZ)
+# SPDX-FileCopyrightText: 2020 Helmholtz-Zentrum Dresden-Rossendorf (HZDR)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+gitlab_dependencies:
+  - apt-transport-https
+  - curl
+  - gnupg
+  - openssh-server
+  - openssl
+  - tzdata
+gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/debian/"
+gitlab_package_name: "{{ gitlab_edition + '=' + gitlab_version + '-' + gitlab_release if gitlab_version and gitlab_release else gitlab_edition }}"


### PR DESCRIPTION
Hi,

This PR adds Debian 11 as target platform for this role.

Bests