### PR TITLE
Lint molecule files via ansible-lint

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 lint: |
   yamllint --strict --format colored . &&
-  ansible-lint -v --force-color --offline --exclude .pipenv/ .
+  ansible-lint -v --force-color --offline --exclude .pipenv/ . molecule/
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,7 +7,8 @@
 - name: Prepare
   hosts: all
   tasks:
-    - when:
+    - name: Install depenencies for OS family RedHat
+      when:
         - ansible_os_family == 'RedHat'
         - ansible_distribution_major_version | int >= 7
       block:
@@ -19,7 +20,8 @@
             state: present
             update_cache: yes
 
-    - when: ansible_os_family == 'Debian'
+    - name: Install depenencies for OS family Debian
+      when: ansible_os_family == 'Debian'
       block:
         - name: Install missing dependencies
           ansible.builtin.apt:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -33,7 +33,7 @@
       ansible.builtin.uri:
         url: "http://localhost/-/health"
       register: "health_check"
-      failed_when: "'OK' not in health_check.msg or health_check.status!=200"
+      failed_when: "'OK' not in health_check.msg or health_check.status != 200"
 
     - name: "Check GitLab Readiness endpoint"
       ansible.builtin.uri:

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -12,4 +12,4 @@ gitlab_dependencies:
   - yum-utils
 gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/$basearch"
 gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/SRPMS"
-gitlab_package_name: "{{ gitlab_edition + '-' + gitlab_version + '-' + gitlab_release if gitlab_version and gitlab_release  else gitlab_edition  }}"
+gitlab_package_name: "{{ gitlab_edition + '-' + gitlab_version + '-' + gitlab_release if gitlab_version and gitlab_release else gitlab_edition }}"


### PR DESCRIPTION
When providing . as the folder path of the lintables to ansible-lint it does not lint the folder molecule/default/ containing converge.yml, prepare.yml, verify.yml, hence folder molecule/ need to be added to the ansible-lint call in the molecule lint commands.

Linting violations need to be fixed alongside this change.