### PR TITLE
feat: configure redis sentinel authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,21 @@ use_internal_redis: 'false'
 
 #### Password to Authenticate Redis Services within Cluster
 
-It is recommended to enable authentication for Redis Master, Redis Replica and 
-Redis Sentinel by providing the respective password:
+It is recommended to enable authentication for Redis Master and Redis Replicas
+by providing the respective password:
 
 ```yaml
 redis_password: 'changeme'
+```
+
+_Caution: You have to use your own private and encrypted password here._
+
+#### Password to Authenticate Redis Sentinels
+
+Support for Redis Sentinel password authentication was introduced in GitLab 16.1.
+
+```yaml
+gitlab_redis_sentinel_password: 'changeme'
 ```
 
 _Caution: You have to use your own private and encrypted password here._

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -30,6 +30,7 @@ provisioner:
     host_vars:
       instancegitlab:
         gitlab_edition: "gitlab-ce"
+        gitlab_ip_range: "0.0.0.0/0"
         gitlab_additional_configurations:
           - package:
             - key: "modify_kernel_parameters"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -24,8 +24,11 @@ gitlab_rails['redis_sentinels'] = [
     { "host" => "{{ redis_sentinel_ip }}", "port" => "{{ redis_sentinel_port }}" },
 {% endfor %}
 ]
-gitlab_rails['monitoring_whitelist'] = ["{{ gitlab_ip_range }}"]
+{% if gitlab_redis_sentinel_password | default('') | length %}
+gitlab_rails['redis_sentinels_password'] = "{{ gitlab_redis_sentinel_password }}"
 {% endif %}
+{% endif %}
+gitlab_rails['monitoring_whitelist'] = ["{{ gitlab_ip_range }}"]
 
 {% if use_internal_gitaly %}
 git_data_dirs({"default" => {"path" => "{{ gitlab_git_data_dir }}"} })


### PR DESCRIPTION
* Closes #119 

In addition: Moved `monitoring_whitelist` config option outside the redis config block in the template.