### PR TITLE
refactor: refer to ansible facts through ansible_facts.* namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/ubuntu
 URL to the source package repository (*CentOS* and *AlmaLinux* only).
 
 ```yaml
-gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/SRPMS"
+gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_facts.distribution_major_version }}/SRPMS"
 ```
 
 #### Package Name
@@ -289,7 +289,7 @@ redis_sentinel_port: '26379'
 Range of GitLab IP addresses that are allowed to monitor Redis Sentinel servers:
 
 ```yaml
-gitlab_ip_range: '{{ ansible_default_ipv4.address }}/24'
+gitlab_ip_range: '{{ ansible_facts.default_ipv4.address }}/24'
 ```
 
 ### Variables to be Set if External Gitaly is Used

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,7 +47,7 @@ redis_sentinel_ips: []
 # Port on which Redis Sentinel instances are listening
 redis_sentinel_port: "26379"
 # GitLap IP address range
-gitlab_ip_range: "{{ ansible_default_ipv4.address }}/24"
+gitlab_ip_range: "{{ ansible_facts.default_ipv4.address }}/24"
 
 # Whether to use GitLab Omnibus internal Gitaly
 use_internal_gitaly: "true"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,8 +9,8 @@
   tasks:
     - name: Install depenencies for OS family RedHat
       when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version | int >= 7
+        - ansible_facts.os_family == 'RedHat'
+        - ansible_facts.distribution_major_version | int >= 7
       block:
         - name: Install missing dependencies
           ansible.builtin.yum:
@@ -22,7 +22,7 @@
             update_cache: yes
 
     - name: Install depenencies for OS family Debian
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       block:
         - name: Install missing dependencies
           ansible.builtin.apt:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,7 +12,7 @@
     state: present
 
 - name: "Prepare Debian GitLab installation"
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
   block:
     - name: Install APT GPG key
       ansible.builtin.apt_key:
@@ -23,14 +23,14 @@
 
     - name: Add GitLab APT repository
       ansible.builtin.apt_repository:
-        repo: "deb {{ gitlab_repo_url }} {{ ansible_distribution_release }} main"
+        repo: "deb {{ gitlab_repo_url }} {{ ansible_facts.distribution_release }} main"
         state: present
         filename: "gitlab_{{ gitlab_edition }}"
         mode: '0644'
 
     - name: Add GitLab source APT repository
       ansible.builtin.apt_repository:
-        repo: "deb-src {{ gitlab_repo_url }} {{ ansible_distribution_release }} main"
+        repo: "deb-src {{ gitlab_repo_url }} {{ ansible_facts.distribution_release }} main"
         state: present
         filename: "gitlab_{{ gitlab_edition }}"
         mode: '0644'
@@ -46,7 +46,7 @@
         - not ansible_check_mode
 
 - name: "Install GitLab on RedHat Like OS"
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
   block:
     - name: Add GitLab yum repository
       ansible.builtin.yum_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 ---
 
 - name: Set OS distribution dependent variables
-  ansible.builtin.include_vars: "{{ ansible_facts['distribution'] }}.yml"
+  ansible.builtin.include_vars: "{{ ansible_facts.distribution }}.yml"
 
 - name: Check whether gitlab-rails binary is installed
   ansible.builtin.stat:

--- a/vars/AlmaLinux.yml
+++ b/vars/AlmaLinux.yml
@@ -10,6 +10,6 @@ gitlab_dependencies:
   - policycoreutils
   - tzdata
   - yum-utils
-gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/$basearch"
-gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/SRPMS"
+gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_facts.distribution_major_version }}/$basearch"
+gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_facts.distribution_major_version }}/SRPMS"
 gitlab_package_name: "{{ gitlab_edition + '-' + gitlab_version + '-' + gitlab_release if gitlab_version and gitlab_release else gitlab_edition }}"

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -10,6 +10,6 @@ gitlab_dependencies:
   - policycoreutils
   - tzdata
   - yum-utils
-gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/$basearch"
-gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_distribution_major_version }}/SRPMS"
+gitlab_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_facts.distribution_major_version }}/$basearch"
+gitlab_source_repo_url: "https://packages.gitlab.com/gitlab/{{ gitlab_edition }}/el/{{ ansible_facts.distribution_major_version }}/SRPMS"
 gitlab_package_name: "{{ gitlab_edition + '-' + gitlab_version + '-' + gitlab_release if gitlab_version and gitlab_release else gitlab_edition }}"


### PR DESCRIPTION
Ansible facts, which have historically been written to names like `ansible_*` in the main facts namespace, have been placed in their own new namespace, `ansible_facts.*`.

* Closes #143 